### PR TITLE
TECH-3773 - Add dedup_key + choose a default merge strategy

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -55,7 +55,7 @@ jobs:
             git checkout $BRANCH
             # Check if the latest commit from the upstream is already in the forked repo
             if [ -z "$(git log | grep $UPSTREAM_SHA_SHORT)" ]; then
-              git merge upstream/$BRANCH --no-edit
+              git merge -X theirs upstream/$BRANCH --no-edit
               git push origin $BRANCH
               echo "Branch $BRANCH synced"
             else
@@ -73,6 +73,7 @@ jobs:
             -H 'Content-Type: application/json' \
             -d '{
               "routing_key": "${{ secrets.SYNC_FORK_PD_ROUTING_KEY }}",
+              "dedup_key": "${{ github.repository }}",
               "event_action": "trigger",
               "payload": {
                 "summary": "Sync fork failed for ${{ github.repository }}",

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -55,7 +55,7 @@ jobs:
             git checkout $BRANCH
             # Check if the latest commit from the upstream is already in the forked repo
             if [ -z "$(git log | grep $UPSTREAM_SHA_SHORT)" ]; then
-              git merge -X theirs upstream/$BRANCH --no-edit
+              git merge upstream/$BRANCH --no-edit
               git push origin $BRANCH
               echo "Branch $BRANCH synced"
             else


### PR DESCRIPTION
Using `-X theirs` with `git merge` prioritizes incoming changes over existing ones. The `dedup_key` is to avoid spamming PD with the same error over an over.